### PR TITLE
Use default origin for WebView post message requests

### DIFF
--- a/src/Editor.js
+++ b/src/Editor.js
@@ -147,7 +147,6 @@ class Editor extends React.Component {
         case 'editorReady':
           window.ReactNativeWebView.postMessage(
             JSON.stringify({ type: 'editorReady' }),
-            '*'
           );
           break;
         case 'emitTextChange':
@@ -156,10 +155,10 @@ class Editor extends React.Component {
             type: 'emitTextChange',
             payload: editor.innerHTML
           };
-          window.ReactNativeWebView.postMessage(JSON.stringify(message), '*');
+          window.ReactNativeWebView.postMessage(JSON.stringify(message));
           break;
         case 'console':
-          window.ReactNativeWebView.postMessage(JSON.stringify(message), '*');
+          window.ReactNativeWebView.postMessage(JSON.stringify(message));
           break;
         default:
           console.error('Improper Emission');


### PR DESCRIPTION
# Goal

Android blocks overriding the target origin to cross-site scripting attacks (https://facebook.github.io/react-native/docs/webview.html). When we post a message to the WebView, do not override the target origin.